### PR TITLE
Enable unified palette (aka "Single Palette" option in settings) by default

### DIFF
--- a/split.html
+++ b/split.html
@@ -61,9 +61,13 @@
                     navigator.serviceWorker.register('sw.js');
                 }
                 world = new WorldMorph(document.getElementById('world'));
-                new IDE_Morph().openIn(world);
+                // store the ide in a varibale so we can change the palette mode later
+                const ide = new IDE_Morph();
+	            ide.openIn(world);
                 requestAnimationFrame(loop);
                 plmod()
+                // enable single palette
+                ide.setUnifiedPalette(true);
             };
         </script>
     </head>

--- a/src/gui.js
+++ b/src/gui.js
@@ -7726,6 +7726,8 @@ IDE_Morph.prototype.toggleStageSize = function (isSmall, forcedRatio) {
     }
 };
 
+// not sure how to default snap! to single palette mode so i put in in split.html
+
 IDE_Morph.prototype.toggleUnifiedPalette = function () {
     this.setUnifiedPalette(!this.scene.unifiedPalette);
     this.recordUnsavedChanges();


### PR DESCRIPTION
Make the palette categories scrollable by default, like Scratch. I am not 100% sure how to set it to true by default, so I changed it in `split.html`.

Saw this request on the Snap! forum somewhere. I  am not 100% the best at modding Snap! so let me know if I need to change anything :)